### PR TITLE
Add dynamic category tabs and selection

### DIFF
--- a/app/api/categories/route.ts
+++ b/app/api/categories/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import { todosCollection } from '@/lib/firestoreService';
+
+export async function GET() {
+  try {
+    const snapshot = await todosCollection.select('category').get();
+    const categories = new Set<string>();
+
+    snapshot.forEach((doc) => {
+      const category = doc.get('category');
+      if (typeof category === 'string') {
+        const trimmed = category.trim();
+        if (trimmed.length > 0) {
+          categories.add(trimmed);
+        }
+      }
+    });
+
+    const sortedCategories = Array.from(categories).sort((a, b) =>
+      a.localeCompare(b)
+    );
+
+    return NextResponse.json({ categories: sortedCategories });
+  } catch (error) {
+    console.error('Error fetching categories:', error);
+    return NextResponse.json(
+      {
+        message: 'Failed to fetch categories',
+        error: String(error),
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/todo/route.ts
+++ b/app/api/todo/route.ts
@@ -49,8 +49,12 @@ function serializeTodoDocument(docSnap: FirebaseFirestore.DocumentSnapshot): Tod
     id: docSnap.id,
     title: data.title,
     description: data.description,
-    category: data.category,
-    subCategory: data.subCategory,
+    category:
+      typeof data.category === 'string' ? data.category.trim() : data.category,
+    subCategory:
+      typeof data.subCategory === 'string'
+        ? data.subCategory.trim()
+        : data.subCategory,
     assignee: data.assignee,
     checklist: checklistWithIds,
     position: resolvePosition(data),

--- a/app/globals.css
+++ b/app/globals.css
@@ -78,6 +78,17 @@ p {
   font-family: var(--font-family);
 }
 
+.category-new-input {
+  display: flex;
+  gap: var(--spacing-unit);
+  align-items: center;
+}
+
+.category-new-input input {
+  flex: 1;
+  min-width: 220px;
+}
+
 .form-group textarea {
   min-height: 100px;
   resize: vertical;
@@ -117,6 +128,48 @@ p {
 .button-group {
   display: flex;
   gap: var(--spacing-unit);
+}
+
+.category-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-unit);
+  margin-bottom: calc(var(--spacing-unit) * 2);
+}
+
+.category-tab {
+  padding: calc(var(--spacing-unit) * 1.25) calc(var(--spacing-unit) * 1.75);
+  border: 1px solid var(--border-color);
+  background-color: #f8f9fa;
+  border-radius: calc(var(--spacing-unit) / 2);
+  cursor: pointer;
+  font-size: 0.95rem;
+  transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out;
+}
+
+.category-tab:hover,
+.category-tab:focus {
+  background-color: #e2e6ea;
+  border-color: var(--primary-color);
+  outline: none;
+}
+
+.category-tab.is-active {
+  background-color: var(--primary-color);
+  color: #fff;
+  border-color: var(--primary-color);
+}
+
+.category-content {
+  margin-top: calc(var(--spacing-unit) * 2);
+}
+
+.category-section + .category-section {
+  margin-top: calc(var(--spacing-unit) * 3);
+}
+
+.category-section h3 {
+  margin-bottom: var(--spacing-unit);
 }
 
 /* Layout & Containers */

--- a/components/CategoryPicker.tsx
+++ b/components/CategoryPicker.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+interface CategoryPickerProps {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}
+
+const ADD_NEW_OPTION = '__category_add_new__';
+
+const normalizeCategory = (category: string) => category.trim();
+
+const CategoryPicker: React.FC<CategoryPickerProps> = ({
+  id,
+  label,
+  value,
+  onChange,
+  placeholder,
+}) => {
+  const [categories, setCategories] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const [isAddingNew, setIsAddingNew] = useState(false);
+  const [previousSelection, setPreviousSelection] = useState('');
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchCategories = async () => {
+      setLoading(true);
+      setFetchError(null);
+      try {
+        const res = await fetch('/api/categories');
+        if (!res.ok) {
+          throw new Error('Failed to load categories');
+        }
+        const data: { categories: string[] } = await res.json();
+        if (isMounted) {
+          const uniqueCategories = Array.from(
+            new Set(
+              (data.categories || [])
+                .map((category) => normalizeCategory(category))
+                .filter((category) => category.length > 0)
+            )
+          ).sort((a, b) => a.localeCompare(b));
+          setCategories(uniqueCategories);
+        }
+      } catch (error: any) {
+        if (isMounted) {
+          setFetchError(error.message || 'Unable to load categories');
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchCategories();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!value) {
+      return;
+    }
+    const normalizedValue = normalizeCategory(value);
+    if (!normalizedValue) {
+      return;
+    }
+    if (!categories.includes(normalizedValue)) {
+      setIsAddingNew(true);
+    }
+  }, [value, categories]);
+
+  const handleSelectChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const selected = event.target.value;
+    if (selected === ADD_NEW_OPTION) {
+      setPreviousSelection(value);
+      setIsAddingNew(true);
+      onChange('');
+      return;
+    }
+    setIsAddingNew(false);
+    onChange(selected);
+  };
+
+  const handleStartAddingNew = () => {
+    setPreviousSelection(value);
+    setIsAddingNew(true);
+    onChange('');
+  };
+
+  const handleCancelAddNew = () => {
+    setIsAddingNew(false);
+    const fallback = previousSelection || categories[0] || '';
+    onChange(fallback);
+  };
+
+  const handleNewCategoryChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    onChange(event.target.value);
+  };
+
+  const renderSelect = () => {
+    if (loading) {
+      return <p className="meta" role="status">Loading categories...</p>;
+    }
+
+    if (fetchError) {
+      return (
+        <div className="meta" role="alert">
+          <p>Unable to load categories. You can still add a new one below.</p>
+          <button
+            type="button"
+            className="button button-secondary"
+            onClick={handleStartAddingNew}
+          >
+            Add new category
+          </button>
+        </div>
+      );
+    }
+
+    if (categories.length === 0) {
+      return (
+        <div>
+          <p className="meta">No categories yet. Create the first one:</p>
+          {renderNewCategoryInput(false)}
+        </div>
+      );
+    }
+
+    return (
+      <select id={id} value={value} onChange={handleSelectChange}>
+        <option value="">Select a category</option>
+        {categories.map((category) => (
+          <option key={category} value={category}>
+            {category}
+          </option>
+        ))}
+        <option value={ADD_NEW_OPTION}>+ Add a new category</option>
+      </select>
+    );
+  };
+
+  const renderNewCategoryInput = (showCancelButton = true) => (
+    <div className="category-new-input">
+      <input
+        type="text"
+        id={id}
+        value={value}
+        onChange={handleNewCategoryChange}
+        placeholder={placeholder || 'Enter a new category'}
+        required
+      />
+      {showCancelButton && categories.length > 0 && (
+        <button
+          type="button"
+          className="button button-secondary"
+          onClick={handleCancelAddNew}
+        >
+          Back to list
+        </button>
+      )}
+    </div>
+  );
+
+  return (
+    <div className="form-group">
+      <label htmlFor={id}>{label}</label>
+      {isAddingNew ? renderNewCategoryInput() : renderSelect()}
+    </div>
+  );
+};
+
+export default CategoryPicker;

--- a/components/TodoForm.tsx
+++ b/components/TodoForm.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { Todo, ChecklistItemType, ASSIGNEES, Assignee, TodoDocument } from '@/types';
 import ChecklistItem from './ChecklistItem';
 import CategorySelector from './CategorySelector';
+import CategoryPicker from './CategoryPicker';
 
 import {
   TouchSensor,
@@ -99,11 +100,13 @@ const TodoForm: React.FC<TodoFormProps> = ({ initialData }) => {
   // ✅ Auto-save logic
   useEffect(() => {
     const interval = setInterval(() => {
+      const sanitizedCategory = category.trim();
+      const sanitizedSubCategory = subCategory.trim();
       const currentData: Todo = {
         title,
         description,
-        category,
-        subCategory,
+        category: sanitizedCategory,
+        subCategory: sanitizedSubCategory,
         assignee,
         checklist: checklist.filter((item) => item.text.trim() !== ''),
       };
@@ -159,17 +162,27 @@ const TodoForm: React.FC<TodoFormProps> = ({ initialData }) => {
     setIsSubmitting(true);
     setError(null);
 
-    if (!title.trim()) {
+    const trimmedTitle = title.trim();
+    const trimmedCategory = category.trim();
+    const trimmedSubCategory = subCategory.trim();
+
+    if (!trimmedTitle) {
       setError('Title is required.');
       setIsSubmitting(false);
       return;
     }
 
+    if (!trimmedCategory) {
+      setError('Category is required.');
+      setIsSubmitting(false);
+      return;
+    }
+
     const todoData: Todo = {
-      title,
+      title: trimmedTitle,
       description,
-      category,
-      subCategory,
+      category: trimmedCategory,
+      subCategory: trimmedSubCategory,
       assignee,
       checklist: checklist.filter((item) => item.text.trim() !== ''),
     };
@@ -266,7 +279,7 @@ const TodoForm: React.FC<TodoFormProps> = ({ initialData }) => {
         />
       </div>
 
-      <CategorySelector
+      <CategoryPicker
         id="category"
         label="Category"
         value={category}


### PR DESCRIPTION
## Summary
- add an API route that exposes the list of distinct todo categories
- replace the category text input with a picker that lets users select an existing category or create a new one
- reorganize the home page into category tabs, update ordering logic, and adjust styling so todos are grouped by category

## Testing
- `npm run build` *(fails: requires a valid FIREBASE_SERVICE_ACCOUNT private key for firebase-admin)*

------
https://chatgpt.com/codex/tasks/task_e_68f7fa2f4b74832f913498c08ef98ecb