### PR TITLE
Normalize course expiration dates when editing todos

### DIFF
--- a/app/api/todo/route.ts
+++ b/app/api/todo/route.ts
@@ -38,12 +38,46 @@ function resolvePosition(data: any): number {
   return Date.now();
 }
 
+function normalizeExpirationDate(value: any): string | null {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    const parsed = Date.parse(trimmed);
+    if (Number.isFinite(parsed)) {
+      return new Date(parsed).toISOString().slice(0, 10);
+    }
+
+    return null;
+  }
+
+  if (value && typeof value === 'object') {
+    if (typeof value.toDate === 'function') {
+      return value.toDate().toISOString().slice(0, 10);
+    }
+
+    if (typeof value._seconds === 'number') {
+      const milliseconds = value._seconds * 1000 + (value._nanoseconds || 0) / 1e6;
+      return new Date(milliseconds).toISOString().slice(0, 10);
+    }
+  }
+
+  return null;
+}
+
 function serializeTodoDocument(docSnap: FirebaseFirestore.DocumentSnapshot): TodoApiResponse {
   const data = docSnap.data()!;
-  const checklistWithIds: ChecklistItemType[] = (data.checklist || []).map((item: any, idx: number) => ({
-    ...item,
-    id: item.id || `item-${idx}-${Date.now()}`,
-  }));
+  const checklistWithIds: ChecklistItemType[] = (data.checklist || []).map((item: any, idx: number) => {
+    const expirationDate = normalizeExpirationDate(item?.expirationDate);
+
+    return {
+      ...item,
+      id: item?.id || `item-${idx}-${Date.now()}`,
+      expirationDate,
+    };
+  });
 
   return {
     id: docSnap.id,


### PR DESCRIPTION
## Summary
- normalize expiration dates returned from the todo API so course checklist items keep their stored values
- normalize loaded expiration dates inside the todo form to display existing course expirations while editing

## Testing
- npm run build *(fails: FIREBASE_SERVICE_ACCOUNT env variable is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_69091b497698832fb63844a5043b46c2