### PR TITLE
Normalize course checklist expiration dates

### DIFF
--- a/app/api/todo/route.ts
+++ b/app/api/todo/route.ts
@@ -43,6 +43,7 @@ function serializeTodoDocument(docSnap: FirebaseFirestore.DocumentSnapshot): Tod
   const checklistWithIds: ChecklistItemType[] = (data.checklist || []).map((item: any, idx: number) => ({
     ...item,
     id: item.id || `item-${idx}-${Date.now()}`,
+    expirationDate: normalizeExpirationDate(item.expirationDate),
   }));
 
   return {
@@ -61,6 +62,66 @@ function serializeTodoDocument(docSnap: FirebaseFirestore.DocumentSnapshot): Tod
     createdAt: toIsoDate(data.createdAt),
     updatedAt: toIsoDate(data.updatedAt),
   };
+}
+
+function formatDateInput(date: Date | null): string | null {
+  if (!(date instanceof Date)) {
+    return null;
+  }
+
+  const time = date.getTime();
+  if (!Number.isFinite(time)) {
+    return null;
+  }
+
+  return new Date(time).toISOString().slice(0, 10);
+}
+
+function normalizeExpirationDate(value: any): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (value instanceof Timestamp) {
+    return formatDateInput(value.toDate());
+  }
+
+  if (typeof value === 'object') {
+    if (typeof value.toDate === 'function') {
+      return formatDateInput(value.toDate());
+    }
+
+    if (typeof value._seconds === 'number') {
+      const nanos = typeof value._nanoseconds === 'number' ? value._nanoseconds : 0;
+      return formatDateInput(new Timestamp(value._seconds, nanos).toDate());
+    }
+
+    if (typeof value.seconds === 'number') {
+      const milliseconds =
+        value.seconds * 1000 + Math.floor((typeof value.nanoseconds === 'number' ? value.nanoseconds : 0) / 1_000_000);
+      return formatDateInput(new Date(milliseconds));
+    }
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+      return trimmed;
+    }
+
+    const parsed = Date.parse(trimmed);
+    if (!Number.isFinite(parsed)) {
+      return null;
+    }
+
+    return formatDateInput(new Date(parsed));
+  }
+
+  return null;
 }
 
 export async function GET(request: NextRequest) {


### PR DESCRIPTION
## Summary
- normalize expiration date values when loading and editing course checklist items in the todo form
- ensure todo API responses convert checklist expiration timestamps to date strings to keep existing values visible

## Testing
- npm run build *(fails: FIREBASE_SERVICE_ACCOUNT env variable is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_69091b497698832fb63844a5043b46c2